### PR TITLE
Feature/nested validation

### DIFF
--- a/src/Attributes/ArrayOf.php
+++ b/src/Attributes/ArrayOf.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Anteris\FormRequest\Attributes;
+
+use Anteris\FormRequest\Validators\FakeValidationFactory;
+use Attribute;
+use Illuminate\Http\Request;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ArrayOf implements Rule
+{
+    private array $rules;
+
+    public function __construct(string $class)
+    {
+        $this->rules = $this->generateRulesFor($class);
+    }
+
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+
+    private function generateRulesFor($class): array {
+
+       /*return rules in the following format
+        * return [
+            'first_name' => ['string'],
+            'last_name' => ['string'],
+            'email' => ['string', 'email'],
+        ];*/
+
+        $type = new $class(
+            Request::create('/', 'GET', []),
+            new FakeValidationFactory(
+            new Translator(
+                new ArrayLoader(),
+                'en'
+            )
+        ));
+
+        return $type->getValidationRules();
+    }
+}

--- a/src/Attributes/ObjectOf.php
+++ b/src/Attributes/ObjectOf.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Anteris\FormRequest\Attributes;
+
+use Anteris\FormRequest\Validators\FakeValidationFactory;
+use Attribute;
+use Illuminate\Http\Request;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ObjectOf implements Rule
+{
+    private array $rules;
+
+    public function __construct(string $class)
+    {
+        $this->rules = $this->generateRulesFor($class);
+    }
+
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+
+    private function generateRulesFor($class): array {
+
+       /*return rules in the following format
+        * return [
+            'first_name' => ['string'],
+            'last_name' => ['string'],
+            'email' => ['string', 'email'],
+        ];*/
+
+        $type = new $class(
+            Request::create('/', 'GET', []),
+            new FakeValidationFactory(
+            new Translator(
+                new ArrayLoader(),
+                'en'
+            )
+        ));
+
+        return $type->getValidationRules();
+    }
+}

--- a/src/FormRequestData.php
+++ b/src/FormRequestData.php
@@ -52,7 +52,7 @@ abstract class FormRequestData implements Arrayable
 
         $validated = $this->validationFactory->make(
             $this->request->only($reflection->getPropertyNames()),
-            $reflection->getValidationRules()
+            $this->getValidationRules()
         )->validate();
 
         foreach ($validated as $property => $value) {
@@ -68,5 +68,10 @@ abstract class FormRequestData implements Arrayable
     private function getReflection(): FormRequestDataReflectionClass
     {
         return $this->reflection;
+    }
+
+    public function getValidationRules(): array
+    {
+        return $this->getReflection()->getValidationRules();
     }
 }

--- a/src/FormRequestData.php
+++ b/src/FormRequestData.php
@@ -2,6 +2,7 @@
 
 namespace Anteris\FormRequest;
 
+use Anteris\FormRequest\Attributes\Rule;
 use Anteris\FormRequest\Reflection\FormRequestDataReflectionClass;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Validation\Factory;
@@ -56,6 +57,21 @@ abstract class FormRequestData implements Arrayable
         )->validate();
 
         foreach ($validated as $property => $value) {
+
+            //check if property is a FormRequestData class
+            foreach($reflection->getProperties() as $property_name) {
+                if($property_name->getName() == $property) {
+                    foreach($property_name->getTypes() as $type) {
+                        if(class_exists($type->getName()) && is_subclass_of($type->getName(), FormRequestData::class)) {
+                            $value = new ($type->getName())(
+                                Request::create('/', 'GET', $this->request->$property),
+                                $this->validationFactory
+                            );
+                        }
+                    }
+                }
+            }
+
             $this->{$property} = $value;
         }
     }

--- a/src/Reflection/FormRequestDataReflectionClass.php
+++ b/src/Reflection/FormRequestDataReflectionClass.php
@@ -43,13 +43,28 @@ class FormRequestDataReflectionClass
 
     public function getValidationRules(): array
     {
-        $array = [];
+        $build = [];
 
         /** @var FormRequestDataReflectionProperty $property */
         foreach ($this->getProperties() as $property) {
-            $array[$property->getName()] = $property->getValidationRules();
+            $validation_rules = $property->getValidationRules();
+
+            foreach($validation_rules as $k => $v) {
+                if(is_numeric($k)) {
+                    $build[$property->getName()] = array_unique(array_merge(
+                        $build[$property->getName()] ?? [],
+                        [$v]
+                    ));
+                }
+                else {
+                    $build[$property->getName() . '.*.' . $k] = array_unique(array_merge(
+                        $build[$property->getName() . '.*.' . $k] ?? [],
+                        $v
+                    ));
+                }
+            }
         }
 
-        return $array;
+        return $build;
     }
 }

--- a/src/Reflection/FormRequestDataReflectionClass.php
+++ b/src/Reflection/FormRequestDataReflectionClass.php
@@ -50,18 +50,28 @@ class FormRequestDataReflectionClass
             $validation_rules = $property->getValidationRules();
 
             foreach($validation_rules as $k => $v) {
+                $validation_subject = $property->getName();
+
+                foreach($property->getTypes() as $type) {
+                    //var_dump($type->getName());
+                }
+
+                if($property->hasType('array')) {
+                    $validation_subject .= '.*.' . $k;
+                }
+                else if($property->hasType('object')) {
+                    $validation_subject .= '.' . $k;
+                }
+
+                $rule = $v;
                 if(is_numeric($k)) {
-                    $build[$property->getName()] = array_unique(array_merge(
-                        $build[$property->getName()] ?? [],
-                        [$v]
-                    ));
+                    $rule = [$v];
                 }
-                else {
-                    $build[$property->getName() . '.*.' . $k] = array_unique(array_merge(
-                        $build[$property->getName() . '.*.' . $k] ?? [],
-                        $v
-                    ));
-                }
+
+                $build[$validation_subject] = array_unique(array_merge(
+                    $build[$validation_subject] ?? [],
+                    $rule
+                ));
             }
         }
 

--- a/src/Reflection/FormRequestDataReflectionProperty.php
+++ b/src/Reflection/FormRequestDataReflectionProperty.php
@@ -75,6 +75,7 @@ class FormRequestDataReflectionProperty
         foreach ($attributes as $attribute) {
             $attribute = $attribute->newInstance();
 
+            //TODO array_unique recursive
             $validationRulesArray = array_merge_recursive($validationRulesArray, $attribute->getRules());
         }
 
@@ -90,8 +91,11 @@ class FormRequestDataReflectionProperty
     {
         $rules = [];
 
-        if (! $this->allowsNull()) {
+        if (!$this->allowsNull()) {
             $rules[] = 'required';
+        }
+        else {
+            $rules[] = 'nullable';
         }
 
         if ($this->hasType('string')) {

--- a/src/Validators/FakeValidationFactory.php
+++ b/src/Validators/FakeValidationFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Anteris\FormRequest\Validators;
+
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\Validator;
+
+class FakeValidationFactory extends Factory
+{
+    /**
+     * Validate the given data against the provided rules.
+     *
+     * @param array $data
+     * @param array $rules
+     * @param array $messages
+     * @param array $attributes
+     * @return array
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate(array $data, array $rules, array $messages = [], array $attributes = [])
+    {
+        $this->make($data, $rules, $messages, $attributes);
+
+        return [];
+    }
+
+
+    protected function resolve(array $data, array $rules, array $messages, array $attributes)
+    {
+        return new FakeValidator($this->translator, $data, $rules, $messages, $attributes);
+    }
+}

--- a/src/Validators/FakeValidator.php
+++ b/src/Validators/FakeValidator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Anteris\FormRequest\Validators;
+
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\Validator;
+
+class FakeValidator extends Validator
+{
+    public function validate()
+    {
+        //throw_if($this->fails(), $this->exception, $this);
+
+        return $this->validated();
+    }
+}

--- a/tests/Attributes/AcceptedIfTest.php
+++ b/tests/Attributes/AcceptedIfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\AcceptedIf;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AcceptedTest.php
+++ b/tests/Attributes/AcceptedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Accepted;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ActiveUrlTest.php
+++ b/tests/Attributes/ActiveUrlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ActiveUrl;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AfterOrEqualTest.php
+++ b/tests/Attributes/AfterOrEqualTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\AfterOrEqual;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AfterTest.php
+++ b/tests/Attributes/AfterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\After;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AlphaNumericDashTest.php
+++ b/tests/Attributes/AlphaNumericDashTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\AlphaNumericDash;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AlphaNumericTest.php
+++ b/tests/Attributes/AlphaNumericTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\AlphaNumeric;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/AlphaTest.php
+++ b/tests/Attributes/AlphaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Alpha;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ArrayOfTest.php
+++ b/tests/Attributes/ArrayOfTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Attributes;
+
+use Anteris\FormRequest\Attributes\ArrayOf;
+use Anteris\Tests\FormRequest\Stubs\CreatePersonRequest;
+use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;
+use PHPUnit\Framework\TestCase;
+
+class ArrayOfTest extends TestCase
+{
+    use TestsValidationAttributes;
+
+    public function test_it_is_a_validation_attribute()
+    {
+        $this->assertValidationAttribute(ArrayOf::class);
+    }
+
+    public function test_it_returns_correct_rules()
+    {
+        $validateFor = new ArrayOf(CreatePersonRequest::class);
+
+        $this->assertValidationRules([
+            'first_name' => [
+                'required', 'string'
+            ],
+            'last_name' => [
+                'required', 'string'
+            ],
+            'email' => [
+                'required', 'string', 'email',
+            ],
+        ], $validateFor);
+    }
+}

--- a/tests/Attributes/ArrayTypeTest.php
+++ b/tests/Attributes/ArrayTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ArrayType;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/BailTest.php
+++ b/tests/Attributes/BailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Bail;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/BeforeOrEqualTest.php
+++ b/tests/Attributes/BeforeOrEqualTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\BeforeOrEqual;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/BeforeTest.php
+++ b/tests/Attributes/BeforeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Before;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/BetweenTest.php
+++ b/tests/Attributes/BetweenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Between;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/BooleanTest.php
+++ b/tests/Attributes/BooleanTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Boolean;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ConfirmedTest.php
+++ b/tests/Attributes/ConfirmedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Confirmed;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/CurrentPasswordTest.php
+++ b/tests/Attributes/CurrentPasswordTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\CurrentPassword;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DateEqualsTest.php
+++ b/tests/Attributes/DateEqualsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\DateEquals;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DateFormatTest.php
+++ b/tests/Attributes/DateFormatTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\DateFormat;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DateTest.php
+++ b/tests/Attributes/DateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Date;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DifferentTest.php
+++ b/tests/Attributes/DifferentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Different;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DigitsBetweenTest.php
+++ b/tests/Attributes/DigitsBetweenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\DigitsBetween;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DigitsTest.php
+++ b/tests/Attributes/DigitsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Digits;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/DimensionsTest.php
+++ b/tests/Attributes/DimensionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Dimensions;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/EmailTest.php
+++ b/tests/Attributes/EmailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Email;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/EndsWithTest.php
+++ b/tests/Attributes/EndsWithTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\EndsWith;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ExcludeIfTest.php
+++ b/tests/Attributes/ExcludeIfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ExcludeIf;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ExcludeUnlessTest.php
+++ b/tests/Attributes/ExcludeUnlessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ExcludeUnless;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ExistsTest.php
+++ b/tests/Attributes/ExistsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Exists;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/FileTest.php
+++ b/tests/Attributes/FileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\File;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/FilledTest.php
+++ b/tests/Attributes/FilledTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Filled;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/GreatThanOrEqualToTest.php
+++ b/tests/Attributes/GreatThanOrEqualToTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\GreatThanOrEqualTo;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/GreaterThanTest.php
+++ b/tests/Attributes/GreaterThanTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\GreaterThan;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/IPTest.php
+++ b/tests/Attributes/IPTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\IP;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/IPv4Test.php
+++ b/tests/Attributes/IPv4Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\IPv4;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/IPv6Test.php
+++ b/tests/Attributes/IPv6Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\IPv6;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ImageTest.php
+++ b/tests/Attributes/ImageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Image;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/InTest.php
+++ b/tests/Attributes/InTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\In;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/IntegerTypeTest.php
+++ b/tests/Attributes/IntegerTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\IntegerType;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/JsonTest.php
+++ b/tests/Attributes/JsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Json;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/LessThanOrEqualToTest.php
+++ b/tests/Attributes/LessThanOrEqualToTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\LessThanOrEqualTo;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/LessThanTest.php
+++ b/tests/Attributes/LessThanTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\LessThan;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/MaxTest.php
+++ b/tests/Attributes/MaxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Max;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/MimeTypesTest.php
+++ b/tests/Attributes/MimeTypesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\MimeTypes;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/MimesTest.php
+++ b/tests/Attributes/MimesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Mimes;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/MinTest.php
+++ b/tests/Attributes/MinTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Min;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/MultipleOfTest.php
+++ b/tests/Attributes/MultipleOfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\MultipleOf;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/NotInTest.php
+++ b/tests/Attributes/NotInTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\NotIn;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/NotRegexTest.php
+++ b/tests/Attributes/NotRegexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\NotRegex;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/NullableTest.php
+++ b/tests/Attributes/NullableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Nullable;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/NumericTest.php
+++ b/tests/Attributes/NumericTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Numeric;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/PasswordDefaultsTest.php
+++ b/tests/Attributes/PasswordDefaultsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\PasswordDefaults;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/PasswordTest.php
+++ b/tests/Attributes/PasswordTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Password;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/PresentTest.php
+++ b/tests/Attributes/PresentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Present;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ProhibitedIfTest.php
+++ b/tests/Attributes/ProhibitedIfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ProhibitedIf;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ProhibitedTest.php
+++ b/tests/Attributes/ProhibitedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Prohibited;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ProhibitedUnlessTest.php
+++ b/tests/Attributes/ProhibitedUnlessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\ProhibitedUnless;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RegexTest.php
+++ b/tests/Attributes/RegexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Regex;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredIfTest.php
+++ b/tests/Attributes/RequiredIfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredIf;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredTest.php
+++ b/tests/Attributes/RequiredTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Required;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredUnlessTest.php
+++ b/tests/Attributes/RequiredUnlessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredUnless;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredWithAllTest.php
+++ b/tests/Attributes/RequiredWithAllTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredWithAll;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredWithTest.php
+++ b/tests/Attributes/RequiredWithTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredWith;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredWithoutAllTest.php
+++ b/tests/Attributes/RequiredWithoutAllTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredWithoutAll;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/RequiredWithoutTest.php
+++ b/tests/Attributes/RequiredWithoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\RequiredWithout;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/SameTest.php
+++ b/tests/Attributes/SameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Same;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/SizeTest.php
+++ b/tests/Attributes/SizeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Size;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/StartsWithTest.php
+++ b/tests/Attributes/StartsWithTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\StartsWith;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/StringTypeTest.php
+++ b/tests/Attributes/StringTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\StringType;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/TimezoneTest.php
+++ b/tests/Attributes/TimezoneTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Timezone;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/UrlTest.php
+++ b/tests/Attributes/UrlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Url;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/UuidTest.php
+++ b/tests/Attributes/UuidTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Uuid;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/Attributes/ValidationTest.php
+++ b/tests/Attributes/ValidationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Anteris\Tests\FormRequest\Attributes;
+namespace Attributes;
 
 use Anteris\FormRequest\Attributes\Validation;
 use Anteris\Tests\FormRequest\Support\TestsValidationAttributes;

--- a/tests/FormRequestDataTest.php
+++ b/tests/FormRequestDataTest.php
@@ -3,6 +3,7 @@
 namespace Anteris\Tests\FormRequest;
 
 use Anteris\Tests\FormRequest\Stubs\AttributesRequest;
+use Anteris\Tests\FormRequest\Stubs\CreateContactListRequest;
 use Anteris\Tests\FormRequest\Stubs\CreatePersonRequest;
 use Anteris\Tests\FormRequest\Stubs\NullablePropertyRequest;
 use Anteris\Tests\FormRequest\Stubs\RequiredPropertyNotNullRequest;

--- a/tests/NestedArrayDataTest.php
+++ b/tests/NestedArrayDataTest.php
@@ -14,7 +14,7 @@ use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\TestCase;
 
-class NestedFormRequestDataTest extends TestCase
+class NestedArrayDataTest extends TestCase
 {
     public function test_it_can_set_properties_when_valid()
     {

--- a/tests/NestedFormRequestDataTest.php
+++ b/tests/NestedFormRequestDataTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Anteris\Tests\FormRequest;
+
+use Anteris\Tests\FormRequest\Stubs\AttributesRequest;
+use Anteris\Tests\FormRequest\Stubs\CreateContactListRequest;
+use Anteris\Tests\FormRequest\Stubs\CreatePersonRequest;
+use Anteris\Tests\FormRequest\Stubs\NullablePropertyRequest;
+use Anteris\Tests\FormRequest\Stubs\RequiredPropertyNotNullRequest;
+use Illuminate\Http\Request;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class NestedFormRequestDataTest extends TestCase
+{
+    public function test_it_can_set_properties_when_valid()
+    {
+        $request = new CreateContactListRequest(
+            $this->createRequest([
+                'name' => 'emergency contacts',
+                'contacts'  => [
+                    [
+                        'first_name' => 'Larry',
+                        'last_name'  => 'Johnson',
+                        'email'      => 'larry.johnson@gmail.com'
+                    ],
+                    [
+                        'first_name' => 'Tammy',
+                        'last_name'  => 'Johnson',
+                        'email'      => 'tammy.johnson@gmail.com',
+                    ]
+                ]
+            ]),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame('emergency contacts', $request->name);
+        $this->assertSame($request->name, $request->getRequest()->name);
+        $this->assertInstanceOf(Request::class, $request->getRequest());
+    }
+
+    public function test_it_can_ignore_sometimes()
+    {
+        $request = new CreateContactListRequest(
+            $this->createRequest([
+                'name' => 'emergency contacts',
+                'contacts' => null
+            ]),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame('emergency contacts', $request->name);
+        $this->assertSame($request->name, $request->getRequest()->name);
+        $this->assertInstanceOf(Request::class, $request->getRequest());
+    }
+
+    public function test_it_throws_exceptions_when_validation_fails()
+    {
+        $this->expectException(ValidationException::class);
+
+        new CreateContactListRequest(
+            $this->createRequest([
+                'name' => 'emergency contacts',
+                'contacts'  => [
+                    [
+                        'first_name' => 'Larry',
+                        'last_name'  => 'Johnson',
+                        'email'      => null
+                    ]
+                ]
+            ]),
+            $this->createValidationFactory()
+        );
+    }
+
+    public function test_to_array()
+    {
+        $data = [
+            'name' => 'emergency contacts',
+            'contacts'  => [
+                [
+                    'first_name' => 'Larry',
+                    'last_name'  => 'Johnson',
+                    'email'      => 'larry.johnson@gmail.com'
+                ]
+            ]
+        ];
+
+        $request = new CreateContactListRequest(
+            $this->createRequest($data),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame(
+            $data,
+            $request->toArray()
+        );
+    }
+
+    private function createRequest(array $data = []): Request
+    {
+        return Request::create('/', 'GET', $data);
+    }
+
+    private function createValidationFactory(): Factory
+    {
+        return new Factory(
+            new Translator(
+                new ArrayLoader(),
+                'en'
+            )
+        );
+    }
+}

--- a/tests/NestedObjectDataTest.php
+++ b/tests/NestedObjectDataTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Anteris\Tests\FormRequest;
+
+use Anteris\Tests\FormRequest\Stubs\AttributesRequest;
+use Anteris\Tests\FormRequest\Stubs\CreateContactListRequest;
+use Anteris\Tests\FormRequest\Stubs\CreatePersonRequest;
+use Anteris\Tests\FormRequest\Stubs\NestedPropertyRequest;
+use Anteris\Tests\FormRequest\Stubs\NullablePropertyRequest;
+use Anteris\Tests\FormRequest\Stubs\OptionalNestedPropertyRequest;
+use Anteris\Tests\FormRequest\Stubs\RequiredPropertyNotNullRequest;
+use Illuminate\Http\Request;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class NestedObjectDataTest extends TestCase
+{
+    public function test_it_can_set_properties_when_valid()
+    {
+        $request = new NestedPropertyRequest(
+            $this->createRequest([
+                'favorite' => [
+                    'first_name' => 'Larry',
+                    'last_name'  => 'Johnson',
+                    'email'      => 'larry.johnson@gmail.com'
+                ],
+            ]),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame('Larry', $request->favorite->first_name);
+        $this->assertSame('Johnson', $request->favorite->last_name);
+        $this->assertSame('larry.johnson@gmail.com', $request->favorite->email);
+
+        $this->assertSame($request->favorite->first_name, $request->getRequest()->favorite['first_name']);
+        $this->assertSame($request->favorite->last_name, $request->getRequest()->favorite['last_name']);
+        $this->assertSame($request->favorite->email, $request->getRequest()->favorite['email']);
+
+        $this->assertInstanceOf(Request::class, $request->getRequest());
+    }
+
+    public function test_it_throws()
+    {
+        $this->expectException(ValidationException::class);
+
+        new NestedPropertyRequest(
+            $this->createRequest([]),
+            $this->createValidationFactory()
+        );
+    }
+
+    public function test_it_throws_when_partial()
+    {
+        $this->expectException(ValidationException::class);
+
+        new NestedPropertyRequest(
+            $this->createRequest([
+                'favorite' => []
+            ]),
+            $this->createValidationFactory()
+        );
+    }
+
+    public function test_it_throws_when_null()
+    {
+        $this->expectException(ValidationException::class);
+
+        new NestedPropertyRequest(
+            $this->createRequest([
+                'favorite' => null
+            ]),
+            $this->createValidationFactory()
+        );
+    }
+
+    public function test_it_can_be_optional_with_value()
+    {
+        $request = new OptionalNestedPropertyRequest(
+            $this->createRequest([
+                'favorite' => [
+                    'first_name' => 'Larry',
+                    'last_name'  => 'Johnson',
+                    'email'      => 'larry.johnson@gmail.com'
+                ],
+            ]),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame('Larry', $request->favorite->first_name);
+        $this->assertSame('Johnson', $request->favorite->last_name);
+        $this->assertSame('larry.johnson@gmail.com', $request->favorite->email);
+
+        $this->assertSame($request->favorite->first_name, $request->getRequest()->favorite['first_name']);
+        $this->assertSame($request->favorite->last_name, $request->getRequest()->favorite['last_name']);
+        $this->assertSame($request->favorite->email, $request->getRequest()->favorite['email']);
+
+        $this->assertInstanceOf(Request::class, $request->getRequest());
+    }
+
+    public function test_it_can_be_optional_without_value()
+    {
+        $request = new OptionalNestedPropertyRequest(
+            $this->createRequest([]),
+            $this->createValidationFactory()
+        );
+
+        $this->assertSame(null, $request->favorite);
+        $this->assertInstanceOf(Request::class, $request->getRequest());
+    }
+
+
+    private function createRequest(array $data = []): Request
+    {
+        return Request::create('/', 'GET', $data);
+    }
+
+    private function createValidationFactory(): Factory
+    {
+        return new Factory(
+            new Translator(
+                new ArrayLoader(),
+                'en'
+            )
+        );
+    }
+}

--- a/tests/Stubs/CreateContactListRequest.php
+++ b/tests/Stubs/CreateContactListRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Anteris\Tests\FormRequest\Stubs;
+
+use Anteris\FormRequest\Attributes\ArrayOf;
+use Anteris\FormRequest\Attributes\Validation;
+use Anteris\FormRequest\FormRequestData;
+
+class CreateContactListRequest extends FormRequestData
+{
+    #[Validation('required', 'string')]
+    public string $name;
+
+    #[Validation('sometimes', 'array', 'nullable'), ArrayOf(CreatePersonRequest::class)]
+    public ?array $contacts = null;
+}

--- a/tests/Stubs/CreateContactListRequest.php
+++ b/tests/Stubs/CreateContactListRequest.php
@@ -11,6 +11,6 @@ class CreateContactListRequest extends FormRequestData
     #[Validation('required', 'string')]
     public string $name;
 
-    #[Validation('sometimes', 'array', 'nullable'), ArrayOf(CreatePersonRequest::class)]
+    #[ArrayOf(CreatePersonRequest::class)]
     public ?array $contacts = null;
 }

--- a/tests/Stubs/NestedPropertyRequest.php
+++ b/tests/Stubs/NestedPropertyRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Anteris\Tests\FormRequest\Stubs;
+
+use Anteris\FormRequest\Attributes\ArrayOf;
+use Anteris\FormRequest\Attributes\Validation;
+use Anteris\FormRequest\FormRequestData;
+
+class NestedPropertyRequest extends FormRequestData
+{
+    public CreatePersonRequest $favorite;
+}

--- a/tests/Stubs/OptionalNestedPropertyRequest.php
+++ b/tests/Stubs/OptionalNestedPropertyRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Anteris\Tests\FormRequest\Stubs;
+
+use Anteris\FormRequest\Attributes\ArrayOf;
+use Anteris\FormRequest\Attributes\Validation;
+use Anteris\FormRequest\FormRequestData;
+
+class OptionalNestedPropertyRequest extends FormRequestData
+{
+    #[Validation('sometimes', 'nullable')]
+    public ?CreatePersonRequest $favorite = null;
+}


### PR DESCRIPTION
- Added support for validating nested objects or nested array of objects

For example:
`public CreatePersonRequest $favorite;`
or 
```
#[ArrayOf(CreatePersonRequest::class)]
public ?array $contacts = null;
```