### PR TITLE
Feature/validated method

### DIFF
--- a/src/FormRequestData.php
+++ b/src/FormRequestData.php
@@ -2,16 +2,16 @@
 
 namespace Anteris\FormRequest;
 
-use Anteris\FormRequest\Attributes\Rule;
 use Anteris\FormRequest\Reflection\FormRequestDataReflectionClass;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
 
 abstract class FormRequestData implements Arrayable
 {
     private FormRequestDataReflectionClass $reflection;
+
+    protected array $validated = [];
 
     final public function __construct(
         private Request $request,
@@ -24,6 +24,11 @@ abstract class FormRequestData implements Arrayable
     public function getRequest(): Request
     {
         return $this->request;
+    }
+
+    public function validated(): array
+    {
+        return $this->validated;
     }
 
     public function except(string ...$keys): array
@@ -52,12 +57,12 @@ abstract class FormRequestData implements Arrayable
     {
         $reflection = $this->getReflection();
 
-        $validated = $this->validationFactory->make(
+        $this->validated = $this->validationFactory->make(
             $this->request->only($reflection->getPropertyNames()),
             $this->getValidationRules()
         )->validate();
 
-        foreach ($validated as $property => $value) {
+        foreach ($this->validated as $property => $value) {
 
             //check if property is a FormRequestData class
             foreach($reflection->getProperties() as $property_name) {

--- a/tests/FormRequestDataTest.php
+++ b/tests/FormRequestDataTest.php
@@ -19,12 +19,14 @@ class FormRequestDataTest extends TestCase
 {
     public function test_it_can_set_properties_when_valid()
     {
+        $data = [
+            'first_name' => 'Aidan',
+            'last_name'  => 'Casey',
+            'email'      => 'aidan.casey@example.com',
+        ];
+
         $personRequest = new CreatePersonRequest(
-            $this->createRequest([
-                'first_name' => 'Aidan',
-                'last_name'  => 'Casey',
-                'email'      => 'aidan.casey@example.com',
-            ]),
+            $this->createRequest($data),
             $this->createValidationFactory()
         );
 
@@ -32,6 +34,8 @@ class FormRequestDataTest extends TestCase
         $this->assertSame('Casey', $personRequest->last_name);
         $this->assertSame('aidan.casey@example.com', $personRequest->email);
         $this->assertInstanceOf(Request::class, $personRequest->getRequest());
+
+        $this->assertSame($data, $personRequest->validated());
     }
 
     public function test_it_throws_exceptions_when_validation_fails()
@@ -76,6 +80,28 @@ class FormRequestDataTest extends TestCase
         );
 
         $this->assertFalse(isset($request->property));
+    }
+
+    public function test_it_does_include_set_sometimes_in_validated()
+    {
+        $data = ['property' => 'Hi!',];
+
+        $request = new NullablePropertyRequest(
+            $this->createRequest($data),
+            $this->createValidationFactory()
+        );
+
+        $this->assertEquals($data, $request->validated());
+    }
+
+    public function test_it_does_not_include_unset_sometimes_in_validated()
+    {
+        $request = new NullablePropertyRequest(
+            $this->createRequest(),
+            $this->createValidationFactory()
+        );
+
+        $this->assertEmpty($request->validated());
     }
 
     public function test_validation_with_attribute_validators()

--- a/tests/FormRequestDataTest.php
+++ b/tests/FormRequestDataTest.php
@@ -84,7 +84,19 @@ class FormRequestDataTest extends TestCase
 
     public function test_it_does_include_set_sometimes_in_validated()
     {
-        $data = ['property' => 'Hi!',];
+        $data = ['property' => 'Hi!'];
+
+        $request = new NullablePropertyRequest(
+            $this->createRequest($data),
+            $this->createValidationFactory()
+        );
+
+        $this->assertEquals($data, $request->validated());
+    }
+
+    public function test_it_does_include_null_value_sometimes_in_validated()
+    {
+        $data = ['property' => null];
 
         $request = new NullablePropertyRequest(
             $this->createRequest($data),


### PR DESCRIPTION
Makes the following possible:
`$request->validated()`

optional properties that are not passed in requests are not included.